### PR TITLE
fix(backend): [NO-ISSUE] fix possible negative number input for order

### DIFF
--- a/backend/app/core/schemas/stock_order.py
+++ b/backend/app/core/schemas/stock_order.py
@@ -1,5 +1,15 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class StockOrder(BaseModel):
 	amount: float
+
+	@field_validator("amount")
+	def validate_amount(cls, v: float) -> float:
+		if v <= 0:
+			raise ValueError("The amount must be greater than 0")
+
+		if v * 10000 % 1 != 0:
+			raise ValueError("The amount must have a maximum of 4 decimal places")
+
+		return v

--- a/backend/app/core/schemas/stock_order.py
+++ b/backend/app/core/schemas/stock_order.py
@@ -9,7 +9,7 @@ class StockOrder(BaseModel):
 		if v <= 0:
 			raise ValueError("The amount must be greater than 0")
 
-		if v * 10000 % 1 != 0:
+		if int(v * 100000) != v * 100000:
 			raise ValueError("The amount must have a maximum of 4 decimal places")
 
 		return v

--- a/backend/app/core/utils/querying_utils.py
+++ b/backend/app/core/utils/querying_utils.py
@@ -360,9 +360,9 @@ class QueryingUtils:
 		session.add(portfolio)
 
 	@staticmethod
-	def get_user_portfolio(session: Session, user_id: str, stock_id: str) -> Portfolio:
+	def get_user_portfolio(session: Session, user_id: str, stock_id: str) -> Portfolio | None:
 		query = select(Portfolio).where(
-			Portfolio.user_id == user_id and Portfolio.company_id == stock_id
+			and_(Portfolio.user_id == user_id, Portfolio.company_id == stock_id)
 		)
 
-		return session.exec(query).one()
+		return session.exec(query).one_or_none()

--- a/backend/tests/order_test.py
+++ b/backend/tests/order_test.py
@@ -215,3 +215,25 @@ def test_sell_invalid_amount(register_user):
 		)
 
 		assert response.status_code == 422
+
+
+def test_sell_valid_amount(register_user):
+	with TestClient(app) as client:
+		client.post(
+			"/api/auth/login",
+			json={"email": register_user["email"], "password": register_user["password"]},
+		)
+
+		response = client.post(
+			"/api/stocks/DOOR/buy",
+			json={"amount": 1.00001},
+		)
+
+		assert response.status_code == 200
+
+		response = client.post(
+			"/api/stocks/DOOR/sell",
+			json={"amount": 0.00001},
+		)
+
+		assert response.status_code == 200

--- a/backend/tests/order_test.py
+++ b/backend/tests/order_test.py
@@ -33,8 +33,6 @@ def test_buy_order(register_user):
 			json={"amount": 1},
 		)
 
-		print(response.json())
-
 		assert response.status_code == 200
 		assert "amount" in response.json()
 		assert "unit_price" in response.json()
@@ -54,8 +52,6 @@ def test_sell_order(register_user):
 			"/api/stocks/DOOR/sell",
 			json={"amount": 1},
 		)
-
-		print(response.json())
 
 		assert response.status_code == 200
 		assert "amount" in response.json()
@@ -77,8 +73,6 @@ def test_buy_order_insufficient_funds(register_user):
 			json={"amount": 100000},
 		)
 
-		print(response.json())
-
 		assert response.status_code == 402
 		assert "detail" in response.json()
 		assert response.json()["detail"] == "Insufficient funds"
@@ -95,8 +89,6 @@ def test_buy_order_invalid_stock(register_user):
 			"/api/stocks/INVALID/buy",
 			json={"amount": 1},
 		)
-
-		print(response.json())
 
 		assert response.status_code == 404
 		assert "detail" in response.json()
@@ -115,8 +107,6 @@ def test_sell_order_invalid_stock(register_user):
 			json={"amount": 1},
 		)
 
-		print(response.json())
-
 		assert response.status_code == 404
 		assert "detail" in response.json()
 		assert response.json()["detail"] == "Stock not found"
@@ -134,9 +124,7 @@ def test_sell_order_invalid_amount(register_user):
 			json={"amount": 100000},
 		)
 
-		print(response.json())
-
-		assert response.status_code == 402
+		assert response.status_code == 400
 		assert "detail" in response.json()
 		assert response.json()["detail"] == "Insufficient stocks"
 
@@ -174,3 +162,56 @@ def test_buy_expired_token(register_user):
 		assert response.status_code == 401
 		assert "detail" in response.json()
 		assert response.json()["detail"] == "Unauthorized"
+
+
+def test_sell_not_bought_stock(register_user):
+	with TestClient(app) as client:
+		client.post(
+			"/api/auth/login",
+			json={"email": register_user["email"], "password": register_user["password"]},
+		)
+
+		response = client.post(
+			"/api/stocks/DOOR/sell",
+			json={"amount": 1},
+		)
+
+		assert response.status_code == 400
+		assert "detail" in response.json()
+		assert response.json()["detail"] == "Insufficient stocks"
+
+
+def test_sell_negative_amount(register_user):
+	with TestClient(app) as client:
+		client.post(
+			"/api/auth/login",
+			json={"email": register_user["email"], "password": register_user["password"]},
+		)
+
+		response = client.post(
+			"/api/stocks/DOOR/sell",
+			json={"amount": -1},
+		)
+
+		assert response.status_code == 422
+
+
+def test_sell_invalid_amount(register_user):
+	with TestClient(app) as client:
+		client.post(
+			"/api/auth/login",
+			json={"email": register_user["email"], "password": register_user["password"]},
+		)
+
+		response = client.post(
+			"/api/stocks/DOOR/sell",
+			json={"amount": 0.000001},
+		)
+		assert response.status_code == 422
+
+		response = client.post(
+			"/api/stocks/DOOR/sell",
+			json={"amount": 1.000001},
+		)
+
+		assert response.status_code == 422


### PR DESCRIPTION
… order, 500 on bad sell

## Summary by Sourcery

Prevent selling stocks with negative amounts and non-existent stocks.

Bug Fixes:

- Fixed an issue where users could sell stocks with negative amounts.
- Fixed an issue where users could sell stocks they did not own.

Enhancements:

- Improved validation of stock order amounts to ensure they are positive and have a maximum of 4 decimal places.
- Return a 400 error instead of 402 when selling non-existent stocks.
- Return a 422 error when selling stocks with invalid amounts.

Tests:

- Added tests to cover selling stocks with negative amounts and non-existent stocks.